### PR TITLE
Better python documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "prettify": "sed -i '.bak' 's/\\/index\\.html//g' _site/**/*.html _site/*.html _site/*.json && rm -rf _site/**/*.bak",
-    "prepare": "cp -R ../abbot-py-docs/_build/html/docfx_yaml/ src/reference/python && npm run compile",
+    "prepare": "cp -R ../abbot-py-docs/_build/html/docfx_yaml/ src/reference/python && cp ../abbot-py-docs/_static/toc.yml src/reference/python && npm run compile",
     "compile": "dotnet build ../abbot/src/Abbot.Scripting.Interfaces/Abbot.Scripting.Interfaces.csproj --configuration Release -o _build",
     "watch": "npm run prepare && npm-watch",
     "build": "npm run prepare && docfx src/docfx.json && npm run prettify",

--- a/src/docfx.json
+++ b/src/docfx.json
@@ -89,7 +89,8 @@
     "fileMetadataFiles": [],
     "template": [
       "default",
-      "templates/abbot"
+      "templates/abbot",
+      "templates/abbot/partials"
     ],
     "postProcessors": [],
     "markdownEngineName": "markdig",

--- a/src/templates/abbot/partials/uref/class.tmpl.partial
+++ b/src/templates/abbot/partials/uref/class.tmpl.partial
@@ -1,0 +1,297 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+{{>partials/uref/class.header}}
+{{#children}}
+
+{{! syntax.variables added for Python classes}}
+{{#syntax.variables.0}}
+<h3>Properties</h3>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+{{/syntax.variables.0}}
+{{#syntax.variables}}
+  <tr>
+      <td><i>{{id}}</i></td>
+      <td>{{description}}</td>
+  </tr>
+{{/syntax.variables}}
+{{#syntax.variables.0}}
+  </table>
+{{/syntax.variables.0}}
+{{! End additions for Python}}
+
+<h3 id="{{id}}">{{>partials/classSubtitle}}</h3>
+
+{{#children}}
+{{^_disableContribution}}
+{{#docurl}}
+<span class="small pull-right mobile-hide">
+  <span class="divider">|</span>
+  <a href="{{docurl}}">{{__global.improveThisDoc}}</a>
+</span>{{/docurl}}
+{{#sourceurl}}
+<span class="small pull-right mobile-hide">
+  <a href="{{sourceurl}}">{{__global.viewSource}}</a>
+</span>{{/sourceurl}}
+{{/_disableContribution}}
+
+{{#overload}}
+<a id="{{id}}" data-uid="{{uid}}"></a>
+{{/overload}}
+<h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
+<div class="markdown level1 summary">{{{summary}}}</div>
+<div class="markdown level1 conceptual">{{{conceptual}}}</div>
+<h5 class="decalaration">{{__global.declaration}}</h5>
+{{#syntax}}
+<div class="codewrapper">
+  <pre><code class="lang-{{syntax.content.0.lang}} hljs">{{syntax.content.0.value}}</code></pre>
+</div>
+{{#parameters.0}}
+
+<h5 class="parameters">{{__global.parameters}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.name}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+{{/parameters.0}}
+{{#parameters}}
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td><em>{{{id}}}</em></td>
+      <td>
+        {{{description}}}
+        {{>partials/uref/parameters}}
+      </td>
+    </tr>
+{{/parameters}}
+{{#parameters.0}}
+  </tbody>
+</table>
+{{/parameters.0}}
+
+{{#return}}
+<h5 class="returns">{{__global.returns}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{{value.type.0.specName.0.value}}}</td>
+      <td>{{{value.description}}}</td>
+    </tr>
+  </tbody>
+</table>
+{{/return}}
+{{#typeParameters.0}}
+<h5 class="typeParameters">{{__global.typeParameters}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.name}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+{{/typeParameters.0}}
+{{#typeParameters}}
+    <tr>
+      <td><em>{{{id}}}</em></td>
+      <td>{{{description}}}</td>
+    </tr>
+{{/typeParameters}}
+{{#typeParameters.0}}
+  </tbody>
+</table>
+{{/typeParameters.0}}
+{{#fieldValue}}
+<h5 class="fieldValue">{{__global.fieldValue}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{{value.type.0.specName.0.value}}}</td>
+      <td>{{{value.description}}}</td>
+    </tr>
+  </tbody>
+</table>
+{{/fieldValue}}
+{{#propertyValue}}
+<h5 class="propertyValue">{{__global.propertyValue}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{{value.type.0.specName.0.value}}}</td>
+      <td>{{{value.description}}}</td>
+    </tr>
+  </tbody>
+</table>
+{{/propertyValue}}
+{{#eventType}}
+<h5 class="eventType">{{__global.eventType}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+  </tbody>
+</table>
+{{/eventType}}
+{{#variableValue}}
+<h5 class="variableValue">{{__global.variableValue}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{{value.type.0.specName.0.value}}}</td>
+      <td>{{{value.description}}}</td>
+    </tr>
+  </tbody>
+</table>
+{{/variableValue}}
+{{#typeAliasType}}
+<h5 class="typeAliasType">{{__global.typeAliasType}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.description}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{{value.type.0.specName.0.value}}}</td>
+      <td>{{{value.description}}}</td>
+    </tr>
+  </tbody>
+</table>
+{{/typeAliasType}}
+{{/syntax}}
+{{#overridden}}
+<h5 class="overrides">{{__global.overrides}}</h5>
+<div><xref href="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+{{/overridden}}
+{{#implements.0}}
+<h5 class="implements">{{__global.implements}}</h5>
+{{/implements.0}}
+{{#implements}}
+  {{#definition}}
+    <div><xref href="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+  {{/definition}}
+  {{^definition}}
+    <div><xref href="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+  {{/definition}}
+{{/implements}}
+{{#remarks}}
+<h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
+<div class="markdown level1 remarks">{{{remarks}}}</div>
+{{/remarks}}
+{{#example.0}}
+<h5 id="{{id}}_examples">{{__global.examples}}</h5>
+{{/example.0}}
+{{#example}}
+{{{.}}}
+{{/example}}
+{{#exceptions.0}}
+<h5 class="exceptions">{{__global.exceptions}}</h5>
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th>{{__global.type}}</th>
+      <th>{{__global.condition}}</th>
+    </tr>
+  </thead>
+  <tbody>
+{{/exceptions.0}}
+{{#exceptions.0.value}}
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+{{/exceptions.0.value}}
+{{#exceptions.0}}
+  </tbody>
+</table>
+{{/exceptions.0}}
+{{#seealso.0}}
+<h5 id="{{id}}_seealso">{{__global.seealso}}</h5>
+<div class="seealso">
+{{/seealso.0}}
+{{#seealso}}
+  {{#isCref}}
+    <div>{{{type.specName.0.value}}}</div>
+  {{/isCref}}
+  {{^isCref}}
+    <div>{{{url}}}</div>
+  {{/isCref}}
+{{/seealso}}
+{{#seealso.0}}
+</div>
+{{/seealso.0}}
+{{/children}}
+{{/children}}
+{{#extensionMethods.0}}
+<h3 id="extensionmethods">{{__global.extensionMethods}}</h3>
+{{/extensionMethods.0}}
+{{#extensionMethods}}
+<div>
+  {{#definition}}
+    <xref href="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/>
+  {{/definition}}
+  {{^definition}}
+    <xref href="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/>
+  {{/definition}}
+</div>
+{{/extensionMethods}}
+{{#seealso.0}}
+<h3 id="seealso">{{__global.seealso}}</h3>
+<div class="seealso">
+{{/seealso.0}}
+{{#seealso}}
+  {{#isCref}}
+    <div>{{{type.specName.0.value}}}</div>
+  {{/isCref}}
+  {{^isCref}}
+    <div>{{{url}}}</div>
+  {{/isCref}}
+{{/seealso}}
+{{#seealso.0}}
+</div>
+{{/seealso.0}}


### PR DESCRIPTION
This introduces an override partial for Python classes so that we can display class variables in the DocFX site. 

It also copies over a handmade toc.yml from `abbot-py-docs` so that all the objects aren't pushed down into 3 layers of folders in the documentation TOC.