### PR TITLE
Add link to release notes in navigation bar

### DIFF
--- a/src/toc.yml
+++ b/src/toc.yml
@@ -4,3 +4,5 @@
 - name: Bot Reference
   href: reference/
   homepage: reference/index.md
+- name: Release Notes
+  href: https://ab.bot/about/release-notes/


### PR DESCRIPTION
Add a link to Abbot's release notes in the documentation site's navbar.