### PR TITLE
Fix code snippet in hello world guide

### DIFF
--- a/src/guides/hello-world/index.md
+++ b/src/guides/hello-world/index.md
@@ -134,13 +134,13 @@ var (command, argument) = Bot.Arguments;
 
 switch (command.Value) {
     case "add":
-        Add(argument.Value);
+        await Add(argument.Value);
         break;
     case "remove":
-        Remove(argument.Value);
+        await Remove(argument.Value);
         break;
     case "show":
-        Show();
+        await Show();
         break;
     default:
         await Bot.ReplyAsync("I don't know what to do!");


### PR DESCRIPTION
The first shopping list code snippet throws warnings because of the lack of await, and the skill editor does not like that.