### PR TITLE
Playbook section and Template Language Doc

### DIFF
--- a/src/chatops/privacy-and-security/index.md
+++ b/src/chatops/privacy-and-security/index.md
@@ -34,8 +34,8 @@ Skill secrets are kept in Azure Key Vault. It is not possible to view the values
 
 ## Our commitment to privacy
 
-We believe that users have the right to private and secure computing. We continue to refine our approach to ensure that we can give our users the most flexibility possible while also maintaining an environment free of abuse. We are always happy to answer questions about how we handle your data -- send us an email at [help@ab.bot](help@ab.bot) if you have any questions.
+We believe that users have the right to private and secure computing. We continue to refine our approach to ensure that we can give our users the most flexibility possible while also maintaining an environment free of abuse. We are always happy to answer questions about how we handle your data -- send us an email at [help@ab.bot](mailto:help@ab.bot) if you have any questions.
 
 ## I've found a problem and want to report it! 
 
-Please email us at [help@ab.bot](help@ab.bot) if you have found an issue that you'd like to report. 
+Please email us at [help@ab.bot](mailto:help@ab.bot) if you have found an issue that you'd like to report. 

--- a/src/chatops/writing-skills/index.md
+++ b/src/chatops/writing-skills/index.md
@@ -4,6 +4,6 @@ Need something beyond the built-in functionality? You can write your own skills 
 
 ### Supported Languages
 
-* C# ([Api Reference](xref:csharp-bot-reference))
-* JavaScript ([Api Reference](xref:abbot-js))
-* Python ([Api Reference](xref:abbot-py-docs))
+* C# ([Api Reference](xref:csharp-reference))
+* JavaScript ([Api Reference](xref:js-reference))
+* Python ([Api Reference](xref:python-reference))

--- a/src/docfx.json
+++ b/src/docfx.json
@@ -45,6 +45,8 @@
       },
       {
         "files": [
+          "playbooks/**.md",
+          "playbooks/**/toc.yml",
           "convos/**.md",
           "convos/**/toc.yml",
           "chatops/**.md",

--- a/src/playbooks/index.md
+++ b/src/playbooks/index.md
@@ -1,0 +1,3 @@
+# Playbooks
+
+Playbooks are a powerful workflow and automation tool for managing your relationships with customers.

--- a/src/playbooks/template-language.md
+++ b/src/playbooks/template-language.md
@@ -6,13 +6,13 @@ Here, we'll focus on the basics and cover the variables that Abbot makes availab
 
 ## Where can you use templates?
 
-Any playbook step that accepts text input can include a template.
+Any Playbook step that accepts text input can include a template.
 For example, the "Message" input for the "Send Message" step: 
 
 <img width="332" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/33b923cd-33de-4aa1-9920-02a3e9cdb9e5">
 
 In addition, some drop-down inputs support pre-defined templates.
-For example, the "Channel" input for the "Send Message" step supports "Channel from Triggers" which is a template that will be replaced with the channel that triggered the playbook:
+For example, the "Channel" input for the "Send Message" step supports "Channel from Triggers" which is a template that will be replaced with the channel that triggered the Playbook:
 
 <img width="290" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/808b0e25-03ee-43ef-af5c-5c9862e851d0">
 
@@ -30,7 +30,7 @@ Variables are surrounded by double curly braces, like `{{this}}`.
 
 We provide a template "context", which is a set of variables that you can use in your templates.
 Many of these variables are objects that have their own properties, which you can access using dot notation.
-For example `{{trigger.outputs.channel.name}}` will be replaced with the name of the channel that triggered the playbook.
+For example `{{trigger.outputs.channel.name}}` will be replaced with the name of the channel that triggered the Playbook.
 
 ## Template Context
 
@@ -38,7 +38,7 @@ The following variables are available in all templates:
 
 | Variable | Description |
 | -------- | ----------- |
-| `trigger` | Results from the trigger that started the playbook. |
+| `trigger` | Results from the trigger that started the Playbook. |
 | `previous` | Results from the previous step. |
 | `outputs` | A merged view of all the "outputs" from all previous steps. Outputs from later steps override outputs from earlier steps. |
 
@@ -58,16 +58,16 @@ The `previous` variable is also "Step Results" object and has the following prop
 
 | Variable | Description |
 | -------- | ----------- |
-| `previous.id` | The ID of the previous step in the playbook |
-| `previous.outcome` | The outcome of the previous step in the playbook. Will always be `Succeeded`. |
-| `previous.outputs` | A table of output values from the previous step in the playbook. The values in this table vary depending on the step. |
+| `previous.id` | The ID of the previous step in the Playbook |
+| `previous.outcome` | The outcome of the previous step in the Playbook. Will always be `Succeeded`. |
+| `previous.outputs` | A table of output values from the previous step in the Playbook. The values in this table vary depending on the step. |
 
 > [!NOTE]
-> For the first step in a playbook, `previous` will be identical to the `trigger`.
+> For the first step in a Playbook, `previous` will be identical to the `trigger`.
 
 ### The `outputs` object
 
-The `outputs` variable is a table of all the outputs from all previous steps in the playbook.
+The `outputs` variable is a table of all the outputs from all previous steps in the Playbook.
 Unlike, say, `trigger.outputs` which is **just** the outputs from the trigger, or `previous.outputs` which is **just** the outputs from the previous step, this is a merged view of all `outputs` from all steps that have executed.
 If a later step has an output with the same name as an earlier step, the later step's output will override the earlier step's output.
 
@@ -76,7 +76,7 @@ If a later step has an output with the same name as an earlier step, the later s
 Here are some examples of triggers and steps and how you can use their outputs in templates.
 This isn't a full reference of all the outputs available, but it gives a brief overview of what to expect.
 
-### Accessing the channel that triggered the playbook
+### Accessing the channel that triggered the Playbook
 
 If you use a trigger like "Conversation Started", "Reaction Added", "Abbot Added to Channel", or other triggers that are caused by events related to Slack messages, the Slack channel in which that event occurred is available in the `trigger.outputs.channel` object.
 That object has the following properties:
@@ -92,9 +92,9 @@ If you want to mention the Channel in a Slack message, use Slack's [linking synt
 Hey everyone, we got a new customer. They're in <#{{ trigger.outputs.channel.id }}>!
 ```
 
-### Accessing the Customer that triggered the playbook
+### Accessing the Customer that triggered the Playbook
 
-If you trigger a playbook using the "New Customer Created" trigger, a `customer` output is available that contains information about the customer:
+If you trigger a Playbook using the "New Customer Created" trigger, a `customer` output is available that contains information about the customer:
 
 | Variable | Description |
 | -------- | ----------- |
@@ -120,5 +120,5 @@ These make the channel they create available in the `outputs.channel` variable, 
 This example creates a new channel for the customer based on the prefix you specify and the name of the customer.
 For example, given a Customer name of `Funny Business` and a prefix of `cust-`, the channel name will be `cust-funny-business`.
 Then, in a subsequent step, you can use the `outputs.channel.id` template to mention the channel in a message.
-The example playbook above posts a mention of the newly created channel in the `#biz` channel.
+The example Playbook above posts a mention of the newly created channel in the `#biz` channel.
 

--- a/src/playbooks/template-language.md
+++ b/src/playbooks/template-language.md
@@ -1,0 +1,125 @@
+# Abbot Templating Language
+
+Inputs provided to Playbook Steps can be templates that will be rendered using the Abbot Templating Language, which is derived from [Handlebars](https://handlebarsjs.com).
+Handlebars is a powerful templating language that allows you to use variables, conditionals, and loops to generate text.
+Here, we'll focus on the basics and cover the variables that Abbot makes available to you, and how to use them.
+
+## Where can you use templates?
+
+Any playbook step that accepts text input can include a template.
+For example, the "Message" input for the "Send Message" step: 
+
+<img width="332" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/33b923cd-33de-4aa1-9920-02a3e9cdb9e5">
+
+In addition, some drop-down inputs support pre-defined templates.
+For example, the "Channel" input for the "Send Message" step supports "Channel from Triggers" which is a template that will be replaced with the channel that triggered the playbook:
+
+<img width="290" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/808b0e25-03ee-43ef-af5c-5c9862e851d0">
+
+Other steps _only_ support template values, such as the "Condition" in the "Continue If" step, which only allows a template from a predefined set of templates:
+
+<img width="295" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/b749b9f4-7b4c-445f-a447-94d01369dfb5">
+
+All of these are implemented with templates, though you only need to write templates when using free-form text inputs.
+
+## Handlebars Basics
+
+Handlebars is a fairly simple templating language.
+Most text is passed through unchanged, but you can use special syntax to insert variables.
+Variables are surrounded by double curly braces, like `{{this}}`.
+
+We provide a template "context", which is a set of variables that you can use in your templates.
+Many of these variables are objects that have their own properties, which you can access using dot notation.
+For example `{{trigger.outputs.channel.name}}` will be replaced with the name of the channel that triggered the playbook.
+
+## Template Context
+
+The following variables are available in all templates:
+
+| Variable | Description |
+| -------- | ----------- |
+| `trigger` | Results from the trigger that started the playbook. |
+| `previous` | Results from the previous step. |
+| `outputs` | A merged view of all the "outputs" from all previous steps. Outputs from later steps override outputs from earlier steps. |
+
+### The `trigger` object
+
+The `trigger` variable is a "Step Results" object and has the following properties:
+
+| Variable | Description |
+| -------- | ----------- |
+| `trigger.id` | The ID of the trigger |
+| `trigger.outcome` | The outcome of the trigger. Will always be `Succeeded`. |
+| `trigger.outputs` | A table of output values from the trigger. The values in this table vary depending on the trigger. |
+
+### The `previous` object
+
+The `previous` variable is also "Step Results" object and has the following properties:
+
+| Variable | Description |
+| -------- | ----------- |
+| `previous.id` | The ID of the previous step in the playbook |
+| `previous.outcome` | The outcome of the previous step in the playbook. Will always be `Succeeded`. |
+| `previous.outputs` | A table of output values from the previous step in the playbook. The values in this table vary depending on the step. |
+
+> [!NOTE]
+> For the first step in a playbook, `previous` will be identical to the `trigger`.
+
+### The `outputs` object
+
+The `outputs` variable is a table of all the outputs from all previous steps in the playbook.
+Unlike, say, `trigger.outputs` which is **just** the outputs from the trigger, or `previous.outputs` which is **just** the outputs from the previous step, this is a merged view of all `outputs` from all steps that have executed.
+If a later step has an output with the same name as an earlier step, the later step's output will override the earlier step's output.
+
+## Some examples
+
+Here are some examples of triggers and steps and how you can use their outputs in templates.
+This isn't a full reference of all the outputs available, but it gives a brief overview of what to expect.
+
+### Accessing the channel that triggered the playbook
+
+If you use a trigger like "Conversation Started", "Reaction Added", "Abbot Added to Channel", or other triggers that are caused by events related to Slack messages, the Slack channel in which that event occurred is available in the `trigger.outputs.channel` object.
+That object has the following properties:
+
+| Variable | Description |
+| -------- | ----------- |
+| `trigger.outputs.channel.id` | The ID of the channel |
+| `trigger.outputs.channel.name` | The name of the channel |
+
+If you want to mention the Channel in a Slack message, use Slack's [linking syntax](https://api.slack.com/reference/surfaces/formatting#linking-channels):
+
+```
+Hey everyone, we got a new customer. They're in <#{{ trigger.outputs.channel.id }}>!
+```
+
+### Accessing the Customer that triggered the playbook
+
+If you trigger a playbook using the "New Customer Created" trigger, a `customer` output is available that contains information about the customer:
+
+| Variable | Description |
+| -------- | ----------- |
+| `trigger.outputs.customer.id` | The ID of the customer |
+| `trigger.outputs.customer.name` | The name of the customer |
+| `trigger.outputs.customer.segments` | A list of the Segments the customer is in |
+| `trigger.outputs.customer.channels` | A list of the Slack channels associated with the customer |
+
+In addition, all of the channels associated with the customer are available in the `trigger.outputs.channels` object.
+The _first_ channel in the channel list is also available in the `trigger.outputs.channel` object, for convenience.
+
+This allows you to send a message to a customer when you create their record in Abbot, for example:
+
+<img width="984" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/a4b8743c-77fc-4e66-9259-15c2f754c37e">
+
+The "Channel from triggers" here is equvalent to the template `trigger.outputs.channel.id`, so this will post a message to the first channel associated with the customer.
+This example assumes you've assigned a channel to the customer when you created their record in Abbot.
+
+There are also steps that _create_ channels, such as "Create Channel for Customer".
+These make the channel they create available in the `outputs.channel` variable, so you can use that in subsequent steps:
+
+<img width="1093" alt="image" src="https://github.com/aseriousbiz/abbot-docs/assets/7574/9d08e2ae-6819-4083-9e44-ec3d228a4205">
+
+This example creates a new channel for the customer based on the prefix you specify and the name of the customer.
+For example, given a Customer name of `Funny Business` and a prefix of `cust-`, the channel name will be `cust-funny-business`.
+Then, in a subsequent step, you can use the `outputs.channel.id` template to mention the channel in a message.
+The example playbook above posts a mention of the newly created channel in the `#biz` channel.
+

--- a/src/playbooks/template-language.md
+++ b/src/playbooks/template-language.md
@@ -98,7 +98,6 @@ If you trigger a playbook using the "New Customer Created" trigger, a `customer`
 
 | Variable | Description |
 | -------- | ----------- |
-| `trigger.outputs.customer.id` | The ID of the customer |
 | `trigger.outputs.customer.name` | The name of the customer |
 | `trigger.outputs.customer.segments` | A list of the Segments the customer is in |
 | `trigger.outputs.customer.channels` | A list of the Slack channels associated with the customer |

--- a/src/playbooks/toc.yml
+++ b/src/playbooks/toc.yml
@@ -1,0 +1,4 @@
+- name: Overview
+  href: index.md
+- name: Template Language
+  href: template-language.md

--- a/src/reference/csharp/index.md
+++ b/src/reference/csharp/index.md
@@ -1,5 +1,5 @@
 ---
-uid: csharp-bot-reference
+uid: csharp-reference
 ---
 
 # C# Bot Reference Overview

--- a/src/reference/toc.yml
+++ b/src/reference/toc.yml
@@ -2,8 +2,10 @@
   href: csharp/toc.yml
   homepage: csharp/index.md
 - name: Python Bot Reference
+  uid: python-reference
   href: python/toc.yml
   homepage: python/index.yml
 - name: JavaScript Bot Reference
+  uid: js-reference
   href: javascript/toc.yml
   homepage: javascript/index.yml

--- a/src/toc.yml
+++ b/src/toc.yml
@@ -1,3 +1,6 @@
+- name: Playbooks
+  href: playbooks/
+  homepage: playbooks/index.md
 - name: Conversation Management
   href: convos/
   homepage: convos/index.md


### PR DESCRIPTION
This adds a Playbooks section to the docs and a brief overview doc describing the Template Language and what variables are available. It's not a full reference but it covers the basics.

In addition, I fixed a few docfx warnings and xref issues.
- Fixes #58 